### PR TITLE
require dotenv to allow custom port setting via .env

### DIFF
--- a/app/bin/www
+++ b/app/bin/www
@@ -7,7 +7,7 @@
 const app = require('../server');
 const debug = require('debug')('app:server');
 const http = require('http');
-
+require('dotenv').config()
 /**
  * Get port from environment and store in Express.
  */


### PR DESCRIPTION
one line add to import dotenv - allows the normalizePort function to reference .env for the first part of its conditional